### PR TITLE
fix: add semver as a needed dep, remove unused dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,12 +203,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "caller": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
-      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU=",
-      "dev": true
-    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -727,16 +721,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fallback-cli": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fallback-cli/-/fallback-cli-2.0.2.tgz",
-      "integrity": "sha1-VGFW4CFAAMosIhedFJlY09rKta8=",
-      "dev": true,
-      "requires": {
-        "caller": "^1.0.0",
-        "resolve": "^1.1.6"
-      }
-    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -772,16 +756,6 @@
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
-      }
-    },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
       }
     },
     "flat-cache": {
@@ -1086,12 +1060,6 @@
         }
       }
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -1261,12 +1229,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
@@ -1329,12 +1291,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -4089,12 +4045,6 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
     "path-to-regexp": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
@@ -4154,17 +4104,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
-    },
-    "proxyquire": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-      "dev": true,
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.8.1"
-      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -4259,15 +4198,6 @@
         "resolve-from": "^1.0.0"
       }
     },
-    "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.5"
-      }
-    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -4356,10 +4286,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4650,15 +4579,6 @@
             "readable-stream": "^2"
           }
         }
-      }
-    },
-    "tap-only": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tap-only/-/tap-only-0.0.5.tgz",
-      "integrity": "sha1-7pnMDs7QqqTVXK1Ci+Yr6HTZ0kg=",
-      "dev": true,
-      "requires": {
-        "fallback-cli": "^2.0.2"
       }
     },
     "tap-parser": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,12 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "tap": "^12.0.1",
-    "tap-only": "0.0.5",
-    "proxyquire": "^2.1.0",
     "sinon": "^6.1.5"
   },
   "dependencies": {
     "acorn": "^5.7.1",
-    "needle": "^2.2.1"
+    "needle": "^2.2.1",
+    "semver": "^5.5.1"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

* Adds a used dep - `semver`
* Removes unused dev deps - `tap-only` and `proxyquire`
