### PR TITLE
test: disabling node10 testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
 language: node_js
 node_js:
   - "8"
-  - "10"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
disable node10 tests from Travis, due to what seems like an issue in Travis.