### PR TITLE
fix: renaming `vulnerableFunctions` to `filters`

### DIFF
--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -19,7 +19,7 @@ function handlePeriodicTasks({agentId,
 function transmitEvents(url, projectId, agentId) {
   let postPromise = Promise.resolve();
   debug(`agent:${agentId} transmitting ${eventsToSend.length} events to ${url} with project ID ${projectId}.`);
-  const body = {projectId, agentId, eventsToSend, systemInfo, instrumentedFunctions};
+  const body = {projectId, agentId, eventsToSend, systemInfo, filters: instrumentedFunctions};
   postPromise = needle('post', url, body, {json: true})
     .then((response) => {
       if (response && response.statusCode !== 200) {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -15,12 +15,12 @@ test('demo app reports a vuln method when called', async (t) => {
       t.ok(beaconData.agentId, 'agentId present in beacon data');
       t.ok(beaconData.systemInfo, 'systemInfo present in beacon data');
       t.ok(!('error' in beaconData.systemInfo), 'systemInfo has no errors');
-      t.ok(beaconData.instrumentedFunctions, 'instrumentedFunctions present in beacon data');
-      t.equal(beaconData.instrumentedFunctions.length, 2, 'two functions instrumented');
-      t.ok('methodName' in beaconData.instrumentedFunctions[0], 'methodName in instrumented function info');
-      t.equal(beaconData.instrumentedFunctions[0].methodName, 'Mount.prototype.getPath', 'correct methodName sent');
-      t.ok('methodName' in beaconData.instrumentedFunctions[1], 'methodName in instrumented function info');
-      t.equal(beaconData.instrumentedFunctions[1].methodName, 'Mime.prototype.lookup', 'correct methodName sent');
+      t.ok(beaconData.filters, 'filters present in beacon data');
+      t.equal(beaconData.filters.length, 2, 'two functions instrumented');
+      t.ok('methodName' in beaconData.filters[0], 'methodName in instrumented function info');
+      t.equal(beaconData.filters[0].methodName, 'Mount.prototype.getPath', 'correct methodName sent');
+      t.ok('methodName' in beaconData.filters[1], 'methodName in instrumented function info');
+      t.equal(beaconData.filters[1].methodName, 'Mime.prototype.lookup', 'correct methodName sent');
       t.ok(beaconData.eventsToSend, 'eventsToSend present in beacon data');
       t.equal(beaconData.eventsToSend.length, 1, 'one event sent');
       t.equal(beaconData.eventsToSend[0].methodEntry.methodName, 'mime.Mime.prototype.lookup', 'only vulnerability on startup is mime.lookup which st imports');
@@ -37,8 +37,8 @@ test('demo app reports a vuln method when called', async (t) => {
       t.ok(beaconData.systemInfo, 'systemInfo present in beacon data');
       t.ok(!('error' in beaconData.systemInfo), 'systemInfo has no errors');
       t.ok(beaconData.eventsToSend, 'eventsToSend present in beacon data');
-      t.ok(beaconData.instrumentedFunctions, 'instrumentedFunctions present in beacon data');
-      t.equal(beaconData.instrumentedFunctions.length, 2, 'two functions instrumented');
+      t.ok(beaconData.filters, 'filters present in beacon data');
+      t.equal(beaconData.filters.length, 2, 'two functions instrumented');
 
       t.equal(beaconData.eventsToSend.length, 2, '2 events sent');
       const beaconEvent = beaconData.eventsToSend[0].methodEntry;


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

renaming `vulnerableFunctions` to `filters` to conform with java agent