### PR TITLE
Parse class members

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -23,58 +23,72 @@ function inspectNode(node, path, cb) {
   if (!node) {
     return;
   }
-  if (node.type === 'FunctionDeclaration') {
-    const loc = node.body.loc.start;
-    const name = node.id.name;
-    cb(path.concat(name), loc);
-  } else if (node.type === 'FunctionExpression') {
-    cb(path, node.body.loc.start);
-  } else if ((node.type === 'ExpressionStatement' && node.expression.right)) {
-    const name = [];
-    const left = node.expression.left;
-
-    if (!left.object) {
-      return;
+  switch (node.type) {
+    case 'FunctionDeclaration': {
+      const loc = node.body.loc.start;
+      const name = node.id.name;
+      cb(path.concat(name), loc);
+      break;
     }
-
-    if (left.object.object && left.object.object.name) {
-      name.push(left.object.object.name);
-      if (left.object.property && left.object.property.name) {
-        name.push(left.object.property.name);
+    case 'FunctionExpression':
+      cb(path, node.body.loc.start);
+      break;
+    case 'ExpressionStatement': {
+      if (!node.expression.right) {
+        return;
       }
-    } else {
-      name.push(left.object.name);
-    }
-    name.push(left.property.name);
+      const name = [];
+      const left = node.expression.left;
 
-    inspectNode(node.expression.right, path.concat(name), cb);
-  } else if (node.type === 'VariableDeclaration') {
-    node.declarations.forEach((decl) => {
-      let newPath;
-      if (decl.init && decl.init.id && decl.init.id.name) {
-        newPath = path.concat(decl.init.id.name);
-      } else if (decl.id && decl.id.name) {
-        newPath = path.concat(decl.id.name);
+      if (!left.object) {
+        return;
       }
 
-      inspectNode(decl.init, newPath, cb);
-    });
-  } else if (node.type === 'ExportNamedDeclaration') {
-    inspectNode(node.declaration, path, cb);
-  } else if (node.type === 'AssignmentExpression') {
-    inspectNode(node.left, path, cb);
-    inspectNode(node.right, path, cb);
-  } else if (node.type === 'ObjectExpression') {
-    for (const prop of node.properties) {
-      inspectNode(prop, path, cb);
+      if (left.object.object && left.object.object.name) {
+        name.push(left.object.object.name);
+        if (left.object.property && left.object.property.name) {
+          name.push(left.object.property.name);
+        }
+      } else {
+        name.push(left.object.name);
+      }
+      name.push(left.property.name);
+
+      inspectNode(node.expression.right, path.concat(name), cb);
+      break;
     }
-  } else if (node.type === 'Property') {
-    const key = node.key;
-    if (key.type !== 'Identifier') {
-      // e.g. { ["concatenation" + "here"]: 5 }
-      return;
-    }
-    inspectNode(node.value, path.concat(key.name), cb);
+    case 'VariableDeclaration':
+      node.declarations.forEach((decl) => {
+        let newPath;
+        if (decl.init && decl.init.id && decl.init.id.name) {
+          newPath = path.concat(decl.init.id.name);
+        } else if (decl.id && decl.id.name) {
+          newPath = path.concat(decl.id.name);
+        }
+
+        inspectNode(decl.init, newPath, cb);
+      });
+      break;
+    case 'ExportNamedDeclaration':
+      inspectNode(node.declaration, path, cb);
+      break;
+    case 'AssignmentExpression':
+      inspectNode(node.left, path, cb);
+      inspectNode(node.right, path, cb);
+      break;
+    case 'ObjectExpression':
+      for (const prop of node.properties) {
+        inspectNode(prop, path, cb);
+      }
+      break;
+    case 'Property':
+      const key = node.key;
+      if (key.type !== 'Identifier') {
+        // e.g. { ["concatenation" + "here"]: 5 }
+        return;
+      }
+      inspectNode(node.value, path.concat(key.name), cb);
+      break;
   }
 }
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -89,6 +89,28 @@ function inspectNode(node, path, cb) {
       }
       inspectNode(node.value, path.concat(key.name), cb);
       break;
+    case 'ClassDeclaration': {
+      const name = node.id;
+      if (name.type !== 'Identifier') {
+        return;
+      }
+      const body = node.body;
+      if (body.type !== 'ClassBody') {
+        return;
+      }
+      body.body.forEach(child => {
+        inspectNode(child, path.concat(`${name.name}.prototype`), cb);
+      });
+      break;
+    }
+    case 'MethodDefinition': {
+      const key = node.key;
+      if (key.type !== 'Identifier') {
+        return;
+      }
+      inspectNode(node.value, path.concat(`${key.name}`), cb);
+      break;
+    }
   }
 }
 

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -51,3 +51,29 @@ module.exports = {
   t.equal(found[methods[1]].line, 4, 'bar found');
   t.end();
 });
+
+test('test class member detection', function (t) {
+  const contents = `
+class Moog {
+  constructor() {}
+  sampleRate(freq) {}
+  static lfo() { return 5; }
+}
+
+module.exports = Moog;
+`;
+  const methods = ['Moog.prototype.constructor', 'Moog.prototype.sampleRate', 'Moog.prototype.lfo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(methods), sorted(Object.keys(found)));
+  t.equal(found[methods[0]].line, 3, 'constructor found');
+  t.equal(found[methods[1]].line, 5, 'sampleRate found');
+  t.equal(found[methods[2]].line, 4, 'lfo found');
+  t.end();
+});
+
+function sorted(list) {
+  list.sort();
+  return list;
+}


### PR DESCRIPTION
#### What does this PR do?

Support member functions declared in classes. This is used in `mime`.

```js
class Moog {
  constructor() {}
  sampleRate(freq) {}
  static lfo() { return 5; }
}

module.exports = Moog;
```

... generates `Moog.prototype.constructor`, `Moog.prototype.sampleRate` and `Moog.prototype.lfo`.

Again, I am not convinced these intermediate names we're using are correct, but they are useful.

#### Where should the reviewer start?

Please read only the second commit; the first was done by IntelliJ. It's kinda readable with whitespace disabled: https://github.com/snyk/nodejs-runtime-agent/commit/103270ec5a48a309721f38a13b8f9a907a90a1cb?w=1

A ClassDeclaration contains a ClassBody, which (inside) has a body, which is a list of declarations inside the class. A MethodDefinition is a .. field assignment of a FunctionExpression, which we already support.
