### PR TITLE
Recurse into lodash-style declarations

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -33,30 +33,9 @@ function inspectNode(node, path, cb) {
     case 'FunctionExpression':
       cb(path, node.body.loc.start);
       break;
-    case 'ExpressionStatement': {
-      if (!node.expression.right) {
-        return;
-      }
-      const name = [];
-      const left = node.expression.left;
-
-      if (!left.object) {
-        return;
-      }
-
-      if (left.object.object && left.object.object.name) {
-        name.push(left.object.object.name);
-        if (left.object.property && left.object.property.name) {
-          name.push(left.object.property.name);
-        }
-      } else {
-        name.push(left.object.name);
-      }
-      name.push(left.property.name);
-
-      inspectNode(node.expression.right, path.concat(name), cb);
+    case 'ExpressionStatement':
+      inspectNode(node.expression, path, cb);
       break;
-    }
     case 'VariableDeclaration':
       node.declarations.forEach((decl) => {
         let newPath;
@@ -72,10 +51,11 @@ function inspectNode(node, path, cb) {
     case 'ExportNamedDeclaration':
       inspectNode(node.declaration, path, cb);
       break;
-    case 'AssignmentExpression':
+    case 'AssignmentExpression': {
       inspectNode(node.left, path, cb);
-      inspectNode(node.right, path, cb);
+      inspectNode(node.right, path.concat(unpackName(node.left)), cb);
       break;
+    }
     case 'ObjectExpression':
       for (const prop of node.properties) {
         inspectNode(prop, path, cb);
@@ -111,7 +91,33 @@ function inspectNode(node, path, cb) {
       inspectNode(node.value, path.concat(`${key.name}`), cb);
       break;
     }
+    case 'EmptyStatement':
+      break;
   }
+}
+
+function unpackName(node) {
+  if (!node) {
+    return [];
+  }
+
+  const name = [];
+  switch (node.type) {
+    case 'MemberExpression': {
+      pushAll(name, unpackName(node.object));
+      pushAll(name, unpackName(node.property));
+      break;
+    }
+    case 'Identifier':
+      name.push(node.name);
+      break;
+  }
+
+  return name;
+}
+
+function pushAll(array, values) {
+  array.push.apply(array, values);
 }
 
 module.exports = {findAllVulnerableFunctionsInScript};

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -32,9 +32,13 @@ function inspectNode(node, path, cb) {
     }
     case 'FunctionExpression':
       cb(path, node.body.loc.start);
+      inspectNode(node.body, path, cb);
       break;
     case 'ExpressionStatement':
       inspectNode(node.expression, path, cb);
+      break;
+    case 'CallExpression':
+      inspectNode(node.callee, path, cb);
       break;
     case 'VariableDeclaration':
       node.declarations.forEach((decl) => {
@@ -59,6 +63,11 @@ function inspectNode(node, path, cb) {
     case 'ObjectExpression':
       for (const prop of node.properties) {
         inspectNode(prop, path, cb);
+      }
+      break;
+    case 'BlockStatement':
+      for (const statement of node.body) {
+        inspectNode(statement, path, cb);
       }
       break;
     case 'Property':
@@ -91,6 +100,10 @@ function inspectNode(node, path, cb) {
       inspectNode(node.value, path.concat(`${key.name}`), cb);
       break;
     }
+    case 'MemberExpression':
+      break;
+    case 'Identifier':
+      break;
     case 'EmptyStatement':
       break;
   }

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -77,6 +77,24 @@ module.exports = Moog;
   t.end();
 });
 
+test('test lodash-CC-style function detection', function (t) {
+  const contents = `
+;(function() {
+  var runInContext = (function yellow(context) {
+    function baseMerge() {}
+  });
+  var _ = runInContext();
+})();
+`;
+  const methods = ['yellow.baseMerge'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].line, 4, 'baseMerge found');
+  t.end();
+});
+
 function sorted(list) {
   const copy = [];
   copy.push.apply(copy, list);

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -10,6 +10,7 @@ test('test st method detection', function (t) {
   const found = ast.findAllVulnerableFunctionsInScript(
     content, methods,
   );
+  t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].line, line, 'Mount.prototype.getPath found');
   t.end();
 });
@@ -21,6 +22,7 @@ test('test handlebars method detection', function (t) {
   const found = ast.findAllVulnerableFunctionsInScript(
     content, methods,
   );
+  t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].line, line, 'escapeExpression found');
   t.end();
 });
@@ -32,6 +34,7 @@ test('test uglify-js method detection', function (t) {
   const found = ast.findAllVulnerableFunctionsInScript(
     content, methods,
   );
+  t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].line, line, 'parse_js_number found');
   t.end();
 });
@@ -47,6 +50,7 @@ module.exports = {
   const found = ast.findAllVulnerableFunctionsInScript(
     contents, methods,
   );
+  t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].line, 3, 'foo found');
   t.equal(found[methods[1]].line, 4, 'bar found');
   t.end();
@@ -66,14 +70,16 @@ module.exports = Moog;
   const found = ast.findAllVulnerableFunctionsInScript(
     contents, methods,
   );
-  t.same(sorted(methods), sorted(Object.keys(found)));
+  t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].line, 3, 'constructor found');
-  t.equal(found[methods[1]].line, 5, 'sampleRate found');
-  t.equal(found[methods[2]].line, 4, 'lfo found');
+  t.equal(found[methods[1]].line, 4, 'sampleRate found');
+  t.equal(found[methods[2]].line, 5, 'lfo found');
   t.end();
 });
 
 function sorted(list) {
-  list.sort();
-  return list;
+  const copy = [];
+  copy.push.apply(copy, list);
+  copy.sort();
+  return copy;
 }


### PR DESCRIPTION
#### What does this PR do?

Support finding functions in lodash's "function armour":
```js
;(function() {
  var runInContext = (function yellow(context) {
    function baseMerge() {}
  });
  var _ = runInContext();
})();
```

In this, we detect `yellow.baseMerge`. This is, again, perhaps not what a node developer would call this method. What should we be generating?

```js
function foo() {
  function bar() {}
}

function pink() {
  function bar() {}
}
```

These are distinct functions, so it feels like they should have distinct names.

#### Where should the reviewer start?

The "extract method" commit sets the stage: An `ExpressionStatement` doesn't really do anything, as far as I can see (this is a pretty typical grammar hack). The old code for reading an `ExpressionStatement` was really reading its embedded `AssignmentStatement`. We already had code to read an `AssignmentStatement`, though! They are now at peace.

Then, we can add a few more statement types, `CallExpression`, `BlockStatement`, etc. and the existing code can cope.
