### PR TITLE
Parse MemberExpression objects

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -25,13 +25,13 @@ function inspectNode(node, path, cb) {
   }
   switch (node.type) {
     case 'FunctionDeclaration': {
-      const loc = node.body.loc.start;
+      const loc = node.body.loc;
       const name = node.id.name;
       cb(path.concat(name), loc);
       break;
     }
     case 'FunctionExpression':
-      cb(path, node.body.loc.start);
+      cb(path, node.body.loc);
       inspectNode(node.body, path, cb);
       break;
     case 'ExpressionStatement':

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -101,6 +101,7 @@ function inspectNode(node, path, cb) {
       break;
     }
     case 'MemberExpression':
+      inspectNode(node.object, path, cb);
       break;
     case 'Identifier':
       break;

--- a/lib/debugger-wrapper.js
+++ b/lib/debugger-wrapper.js
@@ -68,8 +68,8 @@ function instrumentScript(scriptUrl) {
 
 function setBreakpointOnFunction(scriptUrl, moduleInfo, functionName, functionLocation) {
   const breakpointParameters = {
-    lineNumber: functionLocation.line,
-    columnNumber: 0,
+    lineNumber: functionLocation.start.line,
+    columnNumber: functionLocation.start.column,
     url: scriptUrl,
   };
   session.post('Debugger.setBreakpointByUrl', breakpointParameters, (error,response) => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "test"
   },
   "scripts": {
+    "dump": "node test/dump.js",
     "start": "node demo/index.js",
     "test": "npm run lint && tap ./test/*.test.js -R spec",
     "lint": "eslint -c .eslintrc lib"

--- a/test/dump.js
+++ b/test/dump.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const ast = require('../lib/ast.js');
+
+for (let i = 2; i < process.argv.length; ++i) {
+  dump(process.argv[i]);
+}
+
+function dump(path) {
+  const funcs = ast.findAllVulnerableFunctionsInScript(fs.readFileSync(path), {includes: () => true});
+  for (const [name, loc] of Object.entries(funcs)) {
+    console.log(name, showLoc(loc));
+  }
+}
+
+function showLoc(loc) {
+  return `${loc.start.line}c${loc.start.column}` +
+    ` -> ${loc.end.line}c${loc.end.column}`;
+}

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -77,7 +77,7 @@ module.exports = Moog;
   t.end();
 });
 
-test('test lodash-CC-style function detection', function (t) {
+test('test inner function function detection', function (t) {
   const contents = `
 ;(function() {
   var runInContext = (function yellow(context) {
@@ -85,6 +85,24 @@ test('test lodash-CC-style function detection', function (t) {
   });
   var _ = runInContext();
 })();
+`;
+  const methods = ['yellow.baseMerge'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 4, 'baseMerge found');
+  t.end();
+});
+
+test('test lodash-CC-style function detection', function (t) {
+  const contents = `
+;(function() {
+  var runInContext = (function yellow(context) {
+    function baseMerge() {}
+  });
+  var _ = runInContext();
+}.call(this));
 `;
   const methods = ['yellow.baseMerge'];
   const found = ast.findAllVulnerableFunctionsInScript(

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -11,7 +11,7 @@ test('test st method detection', function (t) {
     content, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, line, 'Mount.prototype.getPath found');
+  t.equal(found[methods[0]].start.line, line, 'Mount.prototype.getPath found');
   t.end();
 });
 
@@ -23,7 +23,7 @@ test('test handlebars method detection', function (t) {
     content, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, line, 'escapeExpression found');
+  t.equal(found[methods[0]].start.line, line, 'escapeExpression found');
   t.end();
 });
 
@@ -35,7 +35,7 @@ test('test uglify-js method detection', function (t) {
     content, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, line, 'parse_js_number found');
+  t.equal(found[methods[0]].start.line, line, 'parse_js_number found');
   t.end();
 });
 
@@ -51,8 +51,8 @@ module.exports = {
     contents, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, 3, 'foo found');
-  t.equal(found[methods[1]].line, 4, 'bar found');
+  t.equal(found[methods[0]].start.line, 3, 'foo found');
+  t.equal(found[methods[1]].start.line, 4, 'bar found');
   t.end();
 });
 
@@ -71,9 +71,9 @@ module.exports = Moog;
     contents, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, 3, 'constructor found');
-  t.equal(found[methods[1]].line, 4, 'sampleRate found');
-  t.equal(found[methods[2]].line, 5, 'lfo found');
+  t.equal(found[methods[0]].start.line, 3, 'constructor found');
+  t.equal(found[methods[1]].start.line, 4, 'sampleRate found');
+  t.equal(found[methods[2]].start.line, 5, 'lfo found');
   t.end();
 });
 
@@ -91,7 +91,7 @@ test('test lodash-CC-style function detection', function (t) {
     contents, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
-  t.equal(found[methods[0]].line, 4, 'baseMerge found');
+  t.equal(found[methods[0]].start.line, 4, 'baseMerge found');
   t.end();
 });
 


### PR DESCRIPTION
#### What does this PR do?

Extend the `ast` parser to pick up `MemberExpression` `object`s.

This matters for code like this, which we see in `lodash`:

```js
(function() { function bar() {} }).call(this);
```

The `(function() { function bar() {} })` is the `object` in this case, which they're invoking `call` on.
