### PR TITLE
Correctly identify short methods

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -9,13 +9,18 @@ require('../lib')({
   enable: !process.env.SNYK_RUNTIME_AGENT_DISABLE,
 });
 
+const fs = require('st/node_modules/graceful-fs');
+
 // start running some non-vulnerable function in the background
 // tests may hook into it to make it look vulnerable
 if (process.env.SNYK_TRIGGER_EXTRA_VULN) {
   setInterval(() => {
     try {
+      fs.close(1000);
       st.Mount.prototype.getUrl('whatever');
-    } catch (err) {}
+    } catch (err) {
+      console.log(err);
+    }
   }, 250).unref();
 }
 

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2,8 +2,11 @@ const acorn = require('acorn');
 
 function findAllVulnerableFunctionsInScript(scriptContent, vulnerableFunctionNames) {
   const declaredFunctions = {};
-  const parsedScript = acorn.parse(scriptContent,
-    {locations: true, sourceType: 'module'});
+  const parser = new acorn.Parser(
+    {locations: true, sourceType: 'module'},
+    scriptContent);
+  parser.strict = false;
+  const parsedScript = parser.parse();
   const body = parsedScript.body;
   body.forEach(function (node) {
     inspectNode(node,

--- a/lib/debugger-wrapper.js
+++ b/lib/debugger-wrapper.js
@@ -68,7 +68,7 @@ function instrumentScript(scriptUrl) {
 
 function setBreakpointOnFunction(scriptUrl, moduleInfo, functionName, functionLocation) {
   const breakpointParameters = {
-    lineNumber: functionLocation.start.line,
+    lineNumber: functionLocation.start.line - 1,
     columnNumber: functionLocation.start.column,
     url: scriptUrl,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
     },
     "acorn-jsx": {
       "version": "4.1.1",
@@ -59,6 +59,14 @@
       "dev": true,
       "requires": {
         "acorn": "^5.0.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -617,6 +625,14 @@
       "requires": {
         "acorn": "^5.6.0",
         "acorn-jsx": "^4.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "esprima": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tap": "^12.0.1"
   },
   "dependencies": {
-    "acorn": "^5.7.1",
+    "acorn": "^6.0.4",
     "debug": "^4.0.1",
     "needle": "^2.2.1",
     "semver": "^5.5.1",

--- a/test/debugger.test.js
+++ b/test/debugger.test.js
@@ -16,13 +16,13 @@ class MockSession extends EventEmitter {
   connect() {};
 
   post(method, params, cb) {
-    if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber === 158)) {
+    if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber === 157)) {
       cb(undefined, {breakpointId: 'getPath_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 187)) {
+    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 186)) {
       cb(undefined, {breakpointId: 'serve_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 179)) {
+    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 178)) {
       cb(undefined, {breakpointId: 'getUrl_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber !== 158)) {
+    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber !== 157)) {
       cb({error: 'MY_ERROR_MESSAGE'}, undefined);
     }
   }

--- a/test/method_detection.test.js
+++ b/test/method_detection.test.js
@@ -113,6 +113,21 @@ test('test lodash-CC-style function detection', function (t) {
   t.end();
 });
 
+test('test functions in naughty scripts', function (t) {
+  const contents = `
+function foo() {
+  return 0777;
+}
+`;
+  const methods = ['foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'foo found');
+  t.end();
+});
+
 function sorted(list) {
   const copy = [];
   copy.push.apply(copy, list);


### PR DESCRIPTION
#### What does this PR do?

Enable us to see short methods, like:

```js
function foo() { return 5; }
```

This also fixes us not seeing:
```js
function foo(bar) {
  validate(bar);
  bar.baz();
}
```

... in cases where the validation fails.

Previously, we were picking some point on the first line of the method, which was not useful.

#### Where should the reviewer start?

The use of that `noop` inside `graceful-fs` isn't super elegant, but I was hard pressed to find a one-line function inside the demo's `node_modules`...

