### PR TITLE
Feat/report filters

### DIFF
--- a/lib/debugger-wrapper.js
+++ b/lib/debugger-wrapper.js
@@ -55,6 +55,7 @@ function instrumentScript(scriptUrl) {
     const functionLocation = functionsToInstrument[functionName];
     if (!(functionName in scriptUrlToInstrumentedFunctions[scriptUrl])) {
       setBreakpointOnFunction(scriptUrl, moduleInfo, functionName, functionLocation);
+      transmitter.addFilter(moduleInfo.name, moduleInfo.scriptRelativePath, functionName);
     }
   });
 
@@ -62,6 +63,7 @@ function instrumentScript(scriptUrl) {
     if (!(functionName in functionsToInstrument)) {
       removeBreakpoint(scriptUrlToInstrumentedFunctions[scriptUrl][functionName]);
       delete scriptUrlToInstrumentedFunctions[scriptUrl][functionName];
+      transmitter.removeFilter(moduleInfo.name, moduleInfo.scriptRelativePath, functionName);
     }
   });
 }

--- a/lib/debugger-wrapper.js
+++ b/lib/debugger-wrapper.js
@@ -7,8 +7,8 @@ const transmitter = require('./transmitter');
 
 let session;
 const breakpointsMap = {};
-const scriptUrlToInstrumentedFunctions = {};
 const suspendedBreakpointIds = [];
+const scriptUrlToInstrumentedFunctions = {};
 
 function init() {
   if (!session) {
@@ -77,6 +77,8 @@ function setBreakpointOnFunction(scriptUrl, moduleInfo, functionName, functionLo
       scriptUrlToInstrumentedFunctions[scriptUrl][functionName] = response.breakpointId;
       breakpointsMap[response.breakpointId] = {functionName, moduleInfo, scriptUrl, functionLocation};
       debug(`Successfully set a breakpoint on method ${functionName} in module ${moduleInfo.name}`);
+      // TODO consider more strict conditions for a successful breakpoint
+      // such as testing response.locations[0] against functionLocation
     } else {
       const errorEvent = {functionName, moduleInfo, error, message: 'Failed setting a breakpoint'};
       debug(`Failed setting a breakpoint on method ${functionName} in module ${moduleInfo.name}:`);
@@ -142,9 +144,9 @@ function ignorePause(pauseContext) {
 }
 
 module.exports = {
-  resumeSnoozedBreakpoints,
   init,
-  refreshInstrumentation,
   ignorePause,
+  refreshInstrumentation,
+  resumeSnoozedBreakpoints,
   scriptUrlToInstrumentedFunctions,
 };

--- a/lib/snapshot/reader.js
+++ b/lib/snapshot/reader.js
@@ -4,7 +4,7 @@ const debug = require('debug')('snyk:nodejs-runtime-agent:snapshot');
 
 const config = require('../config');
 
-let lastModified = new Date('Tue, 04 Dec 2017 11:45:42 GMT'); // TODO
+let lastModified;
 let vulnerabiltiesMetadata = {};
 
 module.exports = {

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -4,6 +4,7 @@ const needle = require('needle');
 const config = require('./config');
 const systemInfo = require('./system-info').getSystemInfo();
 
+const filters = {};
 const eventsToSend = [];
 
 function handlePeriodicTasks() {
@@ -14,8 +15,7 @@ function handlePeriodicTasks() {
 function transmitEvents(url, projectId, agentId) {
   let postPromise = Promise.resolve();
   debug(`agent:${agentId} transmitting ${eventsToSend.length} events to ${url} with project ID ${projectId}.`);
-  // TODO filters
-  const body = {projectId, agentId, eventsToSend, systemInfo, filters: []};
+  const body = {projectId, agentId, eventsToSend, systemInfo, filters};
   postPromise = needle('post', url, body, {json: true})
     .then((response) => {
       if (response && response.statusCode !== 200) {
@@ -36,10 +36,36 @@ function clearEvents() {
   eventsToSend.length = 0;
 }
 
+function addFilter(packageName, fileRelativePath, functionName) {
+  if (!(packageName in filters)) {
+    filters[packageName] = {};
+  }
+  if (!(fileRelativePath in filters[packageName])) {
+    filters[packageName][fileRelativePath] = {};
+  }
+  filters[packageName][fileRelativePath][functionName] = null;
+}
+
+function removeFilter(packageName, fileRelativePath, functionName) {
+  delete filters[packageName][fileRelativePath][functionName];
+  if (Object.keys(filters[packageName][fileRelativePath]).length === 0) {
+    delete filters[packageName][fileRelativePath];
+  }
+  if (Object.keys(filters[packageName]).length === 0) {
+    delete filters[packageName];
+  }
+}
+
 function addEvent(event) {
   event.timestamp = (new Date()).toISOString();
   eventsToSend.push(event);
   debug(`Event added to transmission queue: ${JSON.stringify(event)}`);
 }
 
-module.exports = {handlePeriodicTasks, transmitEvents, addEvent};
+module.exports = {
+  addEvent,
+  addFilter,
+  removeFilter,
+  transmitEvents,
+  handlePeriodicTasks,
+};

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -20,6 +20,11 @@ test('demo app reports a vuln method when called', async (t) => {
       t.ok(beaconData.eventsToSend, 'eventsToSend present in beacon data');
       t.equal(beaconData.eventsToSend.length, 1, 'one event sent');
       t.equal(beaconData.eventsToSend[0].methodEntry.methodName, 'mime.Mime.prototype.lookup', 'only vulnerability on startup is mime.lookup which st imports');
+      const expectedFilters = {
+        'st': {'st.js': {'Mount.prototype.getPath': null}},
+        'mime': {'mime.js': {'Mime.prototype.lookup': null}},
+      };
+      t.deepEqual(beaconData.filters, expectedFilters, 'instrumentation appears in beacon');
     });
 
   // second call will have an additional event because we trigger the vuln method
@@ -48,6 +53,11 @@ test('demo app reports a vuln method when called', async (t) => {
       t.same(secondBeaconEvent.coordinates, ['node:mime:1.2.11'], 'proper vulnerable module coordinate');
       t.ok(secondBeaconEvent.sourceUri.endsWith('/mime.js'), 'proper vulnerable module script');
       t.ok(secondBeaconEvent.sourceUri.includes(`node_modules${path.sep}st${path.sep}node_modules${path.sep}mime`), 'proper vulnerable module base dir');
+      const expectedFilters = {
+        'st': {'st.js': {'Mount.prototype.getPath': null}},
+        'mime': {'mime.js': {'Mime.prototype.lookup': null}},
+      };
+      t.deepEqual(beaconData.filters, expectedFilters, 'instrumentation appears in beacon');
     });
 
   // expecting a call to homebase for the newest snapshot
@@ -98,6 +108,11 @@ test('demo app reports a vuln method when called', async (t) => {
     t.ok(methodNames.indexOf('st.Mount.prototype.getPath') !== -1);
     t.ok(methodNames.indexOf('st.Mount.prototype.getUrl') !== -1);
     t.ok(methodNames.indexOf('mime.Mime.prototype.lookup') !== -1);
+    const expectedFilters = {
+      'st': {'st.js': {'Mount.prototype.getPath': null, 'Mount.prototype.getUrl': null}},
+      'mime': {'mime.js': {'Mime.prototype.lookup': null}},
+    };
+    t.deepEqual(beaconData.filters, expectedFilters, 'instrumentation appears in beacon');
   });
 
   // expecting next call to homebase for new snapshot to contain different If-Modified-Since header


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

re-introduce `filter` back to the Node agent's beacons.
`filters` are defined by a <packageName>-<fileRelativePath>-<functionName> 3-tuple and organised in objects.
currently having a filter is equivalent to attempting to set a breakpoint, which is equivalent to us _thinking_ we're monitoring a function.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-98