### PR TITLE
feat: detect ws-style arrow functions

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -30,6 +30,10 @@ function inspectNode(node, path, cb) {
       cb(path.concat(name), loc);
       break;
     }
+    case 'ArrowFunctionExpression': {
+      cb(path, node.loc);
+      break;
+    }
     case 'FunctionExpression':
       cb(path, node.body.loc);
       inspectNode(node.body, path, cb);

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -113,6 +113,23 @@ test('test lodash-CC-style function detection', function (t) {
   t.end();
 });
 
+test('test ws const arrow function detection', function (t) {
+  const contents = `
+const parse = (value) => {
+  console.log("hi!");
+};
+
+module.exports = { parse };
+`;
+  const methods = ['parse'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'parse found');
+  t.end();
+});
+
 function sorted(list) {
   const copy = [];
   copy.push.apply(copy, list);


### PR DESCRIPTION
#### What does this PR do?

Detect arrow functions as functions:
```
const parse = (value) => {
  console.log("hi!");
};
```

We saw this in `c:ws#v:3.3.0#p:lib/Extensions.js`

#### How could this be manually tested?

Create a file named `foo.js`, containing an arrow function (like the above snippet).

```bash
node test/dump.js foo.js
```

See that it prints nothing before the PR, and that it finds the `parse` function after the PR.
