### PR TITLE
feat: detect bootstrap's unary plus wrapper

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -64,6 +64,9 @@ function inspectNode(node, path, cb) {
       inspectNode(node.right, path.concat(unpackName(node.left)), cb);
       break;
     }
+    case 'UnaryExpression':
+      inspectNode(node.argument, path, cb);
+      break;
     case 'ObjectExpression':
       for (const prop of node.properties) {
         inspectNode(prop, path, cb);

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -3,6 +3,26 @@ const test = require('tap').test;
 
 const ast = require('../lib/ast.js');
 
+test('test bootstrap +function method detection', function (t) {
+  const contents = `
++function ($){
+  var Aye = function (one, two) {
+  }
+  Aye.prototype.foo = function (three) {
+  }
+  $.fn.aye = Aye
+}(jQuery);
+`;
+  const methods = ['Aye', 'Aye.prototype.foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 3, 'A found');
+  t.equal(found[methods[1]].start.line, 5, 'A.prototype.foo found');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];


### PR DESCRIPTION
#### What does this PR do?

Previously, we would skip functions declared like:

```js
+function() {
  function foo() {}
}(foo);
```

Yes, there is a plus in front of that function. No, it doesn't seem to do anything reasonable.

```js
> +undefined
NaN
> +function(){}
NaN
> +function(){}()
NaN
```

We now process functions declared inside unary operators.