### PR TITLE
Recurse into all function types

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -26,12 +26,14 @@ function inspectNode(node, path, cb) {
   switch (node.type) {
     case 'FunctionDeclaration': {
       const loc = node.body.loc;
-      const name = node.id.name;
-      cb(path.concat(name), loc);
+      const newPath = path.concat(unpackName(node.id));
+      cb(newPath, loc);
+      inspectNode(node.body, newPath, cb);
       break;
     }
     case 'ArrowFunctionExpression': {
       cb(path, node.loc);
+      inspectNode(node.body, path, cb);
       break;
     }
     case 'FunctionExpression':

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -23,6 +23,22 @@ test('test bootstrap +function method detection', function (t) {
   t.end();
 });
 
+test('test function body method detection', function (t) {
+  const contents = `
+function foo() {
+  function bar() {}
+}
+`;
+  const methods = ['foo', 'foo.bar'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'foo');
+  t.equal(found[methods[1]].start.line, 3, 'foo.bar');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];
@@ -137,16 +153,18 @@ test('test ws const arrow function detection', function (t) {
   const contents = `
 const parse = (value) => {
   console.log("hi!");
+  function foo() {}
 };
 
 module.exports = { parse };
 `;
-  const methods = ['parse'];
+  const methods = ['parse', 'parse.foo'];
   const found = ast.findAllVulnerableFunctionsInScript(
     contents, methods,
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].start.line, 2, 'parse found');
+  t.equal(found[methods[1]].start.line, 4, 'parse.foo found');
   t.end();
 });
 


### PR DESCRIPTION
#### What does this PR do?

Make the `ast` recurse into raw/top-level function declarations.

We will now see:
```
function foo() {
  function bar() {
    function baz() {}
  }
}
```

As `foo`, `foo.bar`, `foo.bar.baz`.

Unfortunately, this means we will now evaluate a whole lot more code than we did before.

#### Where should the reviewer start?

Do we like those names?
