### PR TITLE
Support moment-style wrappers

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -45,6 +45,7 @@ function inspectNode(node, path, cb) {
       break;
     case 'CallExpression':
       inspectNode(node.callee, path, cb);
+      node.arguments.forEach((arg) => inspectNode(arg, path, cb));
       break;
     case 'VariableDeclaration':
       node.declarations.forEach((decl) => {

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -19,7 +19,7 @@ function findAllVulnerableFunctionsInScript(scriptContent, vulnerableFunctionNam
   return declaredFunctions;
 }
 
-function inspectNode(node, path, cb) {
+function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
   if (!node) {
     return;
   }
@@ -32,12 +32,16 @@ function inspectNode(node, path, cb) {
       break;
     }
     case 'ArrowFunctionExpression': {
-      cb(path, node.loc);
+      if (expectingAnonymousDeclaration) {
+        cb(path, node.loc);
+      }
       inspectNode(node.body, path, cb);
       break;
     }
     case 'FunctionExpression':
-      cb(path, node.body.loc);
+      if (expectingAnonymousDeclaration) {
+        cb(path, node.body.loc);
+      }
       inspectNode(node.body, path, cb);
       break;
     case 'ExpressionStatement':
@@ -56,7 +60,7 @@ function inspectNode(node, path, cb) {
           newPath = path.concat(decl.id.name);
         }
 
-        inspectNode(decl.init, newPath, cb);
+        inspectNode(decl.init, newPath, cb, true);
       });
       break;
     case 'ExportNamedDeclaration':
@@ -64,7 +68,7 @@ function inspectNode(node, path, cb) {
       break;
     case 'AssignmentExpression': {
       inspectNode(node.left, path, cb);
-      inspectNode(node.right, path.concat(unpackName(node.left)), cb);
+      inspectNode(node.right, path.concat(unpackName(node.left)), cb, true);
       break;
     }
     case 'UnaryExpression':
@@ -86,7 +90,7 @@ function inspectNode(node, path, cb) {
         // e.g. { ["concatenation" + "here"]: 5 }
         return;
       }
-      inspectNode(node.value, path.concat(key.name), cb);
+      inspectNode(node.value, path.concat(key.name), cb, true);
       break;
     case 'ClassDeclaration': {
       const name = node.id;
@@ -98,7 +102,7 @@ function inspectNode(node, path, cb) {
         return;
       }
       body.body.forEach(child => {
-        inspectNode(child, path.concat(`${name.name}.prototype`), cb);
+        inspectNode(child, path.concat(`${name.name}.prototype`), cb, true);
       });
       break;
     }
@@ -107,7 +111,7 @@ function inspectNode(node, path, cb) {
       if (key.type !== 'Identifier') {
         return;
       }
-      inspectNode(node.value, path.concat(`${key.name}`), cb);
+      inspectNode(node.value, path.concat(`${key.name}`), cb, true);
       break;
     }
     case 'MemberExpression':

--- a/test/debugger.test.js
+++ b/test/debugger.test.js
@@ -16,14 +16,22 @@ class MockSession extends EventEmitter {
   connect() {};
 
   post(method, params, cb) {
-    if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber === 157)) {
-      cb(undefined, {breakpointId: 'getPath_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 186)) {
-      cb(undefined, {breakpointId: 'serve_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber == 178)) {
-      cb(undefined, {breakpointId: 'getUrl_BP_ID'});
-    } else if ((method === 'Debugger.setBreakpointByUrl') && (params.lineNumber !== 157)) {
-      cb({error: 'MY_ERROR_MESSAGE'}, undefined);
+    if ('Debugger.setBreakpointByUrl' !== method) {
+      return;
+    }
+
+    switch (params.lineNumber) {
+      case 157:
+        cb(undefined, {breakpointId: 'getPath_BP_ID'});
+        return;
+      case 186:
+        cb(undefined, {breakpointId: 'serve_BP_ID'});
+        return;
+      case 178:
+        cb(undefined, {breakpointId: 'getUrl_BP_ID'});
+        return;
+      default:
+        cb({error: `mocking has no mock for line number ${params.lineNumber}`}, undefined);
     }
   }
 }
@@ -46,7 +54,7 @@ test('test setting a breakpoint', function (t) {
 
   t.assert(stScriptInfo.params.url in dbg.scriptUrlToInstrumentedFunctions);
   const monitoredFunctionsBefore = dbg.scriptUrlToInstrumentedFunctions[stScriptInfo.params.url];
-  t.equal(Object.keys(monitoredFunctionsBefore).length, 2, 'two monitored functions');
+  t.equal(Object.keys(monitoredFunctionsBefore).length, 2, 'two monitored functions before');
   t.assert('Mount.prototype.getPath' in monitoredFunctionsBefore, 'getPath newly monitored');
   t.equal(monitoredFunctionsBefore['Mount.prototype.getPath'], 'getPath_BP_ID');
   t.assert('Mount.prototype.getUrl' in monitoredFunctionsBefore, 'getUrl newly monitored');
@@ -59,7 +67,7 @@ test('test setting a breakpoint', function (t) {
 
   t.assert(stScriptInfo.params.url in dbg.scriptUrlToInstrumentedFunctions);
   const monitoredFunctionsAfter = dbg.scriptUrlToInstrumentedFunctions[stScriptInfo.params.url];
-  t.equal(Object.keys(monitoredFunctionsAfter).length, 2, 'two monitored functions');
+  t.equal(Object.keys(monitoredFunctionsAfter).length, 2, 'two monitored functions after');
   t.assert('Mount.prototype.getPath' in monitoredFunctionsAfter, 'getPath still monitored');
   t.equal(monitoredFunctionsAfter['Mount.prototype.getPath'], 'getPath_BP_ID');
   t.assert('Mount.prototype.serve' in monitoredFunctionsAfter, 'serve newly monitored');

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -149,6 +149,22 @@ test('test lodash-CC-style function detection', function (t) {
   t.end();
 });
 
+test('test moment-style wrapper detection', function (t) {
+  const contents = `
+;(function () {
+}(this, (function () {
+  function hooks() {}
+})));
+`;
+  const methods = ['hooks'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 4, 'hooks found');
+  t.end();
+});
+
 test('test ws const arrow function detection', function (t) {
   const contents = `
 const parse = (value) => {

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -39,6 +39,21 @@ function foo() {
   t.end();
 });
 
+test('test anonymous function not splatting parent', function (t) {
+  const contents = `
+function foo() {
+  console.log(function() {});
+}
+`;
+  const methods = ['foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'foo');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];


### PR DESCRIPTION
#### What does this PR do?

Recognise `hooks` inside:

```
;(function () {
}(this, (function () {
  function hooks() {}
})));
```

Yes, `moment` really does that.

#### Where should the reviewer start?

Please read the two commits independently, and ignore the cleanup commit. I thought `debugger.test.js` was broken, but it's not!

