### PR TITLE
Feat/report on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ The `config` object supports the following options:
 
 | Key                | Type      | Default value                            | Purpose                                                                 |
 |--------------------|-----------|------------------------------------------|-------------------------------------------------------------------------|
-| `projectId`        | `String`  |                                          | The Snyk project ID that matches your application.                      |
-| `enable`           | `Boolean` | `true`                                   | Set to `false` to disable the agent.                                    |
+| `projectId`        | `String`  |                           | The Snyk project ID that matches your application.                         |
+| `enable`           | `Boolean` | `true`                    | Set to `false` to disable the agent.                                    |
 
 Advanced `config` options:
 
 | Key                  | Type      | Default value                                               | Purpose                                                                                    |
 |----------------------|-----------|-------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| `beaconIntervalMs`   | `Number`  | `60000`                                                     | Report frequency in milliseconds.                                                          |
-| `snapshotIntervalMs` | `Number`  | `3600000`                                                   | Snapshot retrieval frequency in milliseconds.                                              |
+| `beaconIntervalMs`   | `Number`  | `60000`                   | Report frequency in milliseconds.                                                          |
+| `snapshotIntervalMs` | `Number`  | `3600000`                 | Snapshot retrieval frequency in milliseconds.                                              |
+| `flushOnExit`        | `Boolean` | `true`                    | Set to `false` to prevent the agent from flushing its data before exiting. `true` is useful especially for short-lived environments.   |
 
 # Demo
 `npm start` to bring up an http server that invokes a vulnerable function on startup and for every request.

--- a/demo/justrequireagent.js
+++ b/demo/justrequireagent.js
@@ -1,0 +1,19 @@
+const flushOnExit = process.env.flushBeforeExit ? process.env.flushBeforeExit === 'yes' : true;
+const port = process.env.runtimeAgentPort || 9000;
+
+// load the agent
+require('../lib')({
+  url: `http://localhost:${port}/api/v1/beacon`,
+  projectId: 'hurr durr',
+  flushOnExit,
+});
+
+// do some.. stuff
+console.log('henlo!');
+let i = 0;
+while (i < 100) {
+  i += 1;
+}
+
+// and.. we're done!
+console.log('ok bye');

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ function initConfig(startingConfig) {
   const config = {};
 
   config['enable'] = true;
+  config['flushOnExit'] = true;
   config['agentId'] = uuidv4();
   config['beaconIntervalMs'] = 60 * 1000;
   config['snapshotIntervalMs'] = 60 * 60 * 1000;
@@ -35,7 +36,7 @@ function initConfig(startingConfig) {
 
   const overrideables = [
     'snapshotUrl', 'snapshotIntervalMs', 'beaconIntervalMs',
-    'enable', 'projectId', 'functionPaths',
+    'enable', 'flushOnExit', 'projectId', 'functionPaths',
   ];
   for (const key of overrideables) {
     if (key in startingConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,10 @@ function start(startingConfig) {
       return;
     }
 
+    if (config.flushOnExit) {
+      setFlushOnExit();
+    }
+
     snapshot.init();
     debuggerWrapper.init();
 
@@ -60,6 +64,26 @@ function start(startingConfig) {
     // and will be used as a lead to enable debug mode
     console.log('Error while starting Snyk runtime agent, please contact runtime@snyk.io', error);
   };
+}
+
+function setFlushOnExit() {
+  let flushedOnce = false;
+  function handleBeforeExit() {
+    if (flushedOnce) {
+      return;
+    }
+
+    debug('flushing last beacons before exiting');
+    transmitter.handlePeriodicTasks()
+      .then(() => {
+        flushedOnce = true;
+      })
+      .catch(() => {
+        flushedOnce = true;
+      });
+  }
+
+  process.on('beforeExit', handleBeforeExit);
 }
 
 function stopIntervals() {

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -9,7 +9,7 @@ const eventsToSend = [];
 
 function handlePeriodicTasks() {
   const url = config.beaconUrl;
-  transmitEvents(url, config.projectId, config.agentId);
+  return transmitEvents(url, config.projectId, config.agentId);
 }
 
 function transmitEvents(url, projectId, agentId) {

--- a/test/shutdown.test.js
+++ b/test/shutdown.test.js
@@ -1,0 +1,61 @@
+const test = require('tap').test;
+const http = require('http');
+const spawn = require('child_process').spawn;
+
+test('agent transmits before exit by default', t => {
+  t.plan(3);
+
+  // small server the agent can report to, upon exit
+  const server = http.createServer(function (req, res) {
+    t.equal(req.url, '/api/v1/beacon', 'agent reported before shutting down');
+    t.equal(req.method, 'POST');
+    t.equal(req.headers.host, 'localhost:9000');
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('carry on my wayward son!');
+  }).listen(9000)
+
+  // bring up the demo server, then close it
+  var env = Object.create( process.env );
+  env.DEBUG = 'snyk*';
+  env.flushBeforeExit = 'yes';
+  env.runtimeAgentPort = 9000;
+  const demoApp = spawn('node',  ['demo/justrequireagent.js'], {env: env});
+
+  // these snippets are nice for debugging the test
+  // but seem to affect the behaviour of tap :scream:
+  // demoApp.stdout.on('data', function (data) {
+  //   var str = data.toString()
+  //   var lines = str.split(/(\r?\n)/g);
+  //   console.log(lines.join(""));
+  // });
+  // demoApp.stderr.on('data', function (data) {
+  //   var str = data.toString()
+  //   var lines = str.split(/(\r?\n)/g);
+  //   console.log(lines.join(""));
+  // });
+
+  demoApp.on('close', function (code) {
+    server.close();
+  });
+});
+
+test('allow turning flushBeforeExit off', t => {
+  // small server the agent can report to, upon exit
+  const server = http.createServer(function (req, res) {
+    t.fail('agent should not have reported');
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('shame on you!');
+  }).listen(9001)
+
+  // bring up the demo server, then close it
+  var env = Object.create( process.env );
+  env.DEBUG = 'snyk*';
+  env.flushBeforeExit = 'plz no';
+  env.runtimeAgentPort = 9001;
+  const demoApp = spawn('node',  ['demo/justrequireagent.js'], {env: env});
+
+  demoApp.on('close', function (code) {
+    t.end();
+    server.close();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

today, when the Node process running the runtime agent shuts down, we don't do anything special.

we would like to support short-lived environments (such as test environments), so instead of having to set the beacon timer to a very small value, we will just attempt to transmit the data we've collected before shutting down.

we want to avoid being too intrusive, and delay critical shutdowns, so for now we're not handling any shut down types except for the `process:beforeExit` event (https://nodejs.org/api/process.html#process_event_beforeexit) which emits only when the process is about to shut down due to having nothing more to do.

this means that we don't cover:
1. explicit shutdowns (`sys.exit`)
2. unhandled errors
3. OS signals (`SIGINT`, `SIGTERM`)
4. anything else?

this PR introduces a new flag - `flushOnExit`, which is on by default, and controls whether or not we're hooking into the process' exit, and attempt to transmit the last beacons before shutting down.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-126