### PR TITLE
feat: parse in non-strict for e.g. octal

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2,8 +2,10 @@ const acorn = require('acorn');
 
 function findAllVulnerableFunctionsInScript(scriptContent, vulnerableFunctionNames) {
   const declaredFunctions = {};
-  const parsedScript = acorn.parse(scriptContent,
-    {locations: true, sourceType: 'module'});
+  const parser = new acorn.Parser(
+    {locations: true, sourceType: 'module'}, scriptContent);
+  parser.strict = false;
+  const parsedScript = parser.parse();
   const body = parsedScript.body;
   body.forEach(function (node) {
     inspectNode(node,

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -180,6 +180,21 @@ test('test moment-style wrapper detection', function (t) {
   t.end();
 });
 
+test('test octal parsing', function (t) {
+  const contents = `
+function foo() {
+  return 0777;
+}
+`;
+  const methods = ['foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'foo found');
+  t.end();
+});
+
 test('test ws const arrow function detection', function (t) {
   const contents = `
 const parse = (value) => {


### PR DESCRIPTION
#### What does this PR do?

Disable strict parsing, so we can read modules containing e.g. octal numbers.

#### Notes for the reviewer

Those arguments really are the other way around, between `parse()` and `Parser()`.

I have written this exact commit before. If you know where it went, please do let me know. No, really. I'm worried I'm losing it.
