### PR TITLE
Support named functions in expression context

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -40,12 +40,22 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
       inspectNode(node.body, path, cb);
       break;
     }
-    case 'FunctionExpression':
+    case 'FunctionExpression': {
+      let newPath = path;
+      const name = unpackName(node.id);
+
       if (expectingAnonymousDeclaration) {
+        // if we're in a context where anonymous makes sense,
+        // we discard the function name, to avoid duplication
         cb(path, node.body.loc);
+      } else if (0 !== name.length) {
+        newPath = path.concat(name);
+        cb(newPath, node.body.loc);
       }
-      inspectNode(node.body, path, cb);
+
+      inspectNode(node.body, newPath, cb);
       break;
+    }
     case 'ExpressionStatement':
       inspectNode(node.expression, path, cb);
       break;
@@ -118,6 +128,9 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
     }
     case 'MemberExpression':
       inspectNode(node.object, path, cb);
+      break;
+    case 'ReturnStatement':
+      inspectNode(node.argument, path, cb);
       break;
     case 'Identifier':
       break;

--- a/lib/snapshot/index.js
+++ b/lib/snapshot/index.js
@@ -53,7 +53,7 @@ function validateFoundFunctions(scriptPathFunctions, moduleInfo, functionsExpect
   const functionsNotFound = functionsExpected.filter(f => !functionsActual.includes(f));
   if (functionsNotFound && functionsNotFound.length > 0) {
     const warningEvent = {
-      message: 'instrumentation discrepacy: missing functions from source code',
+      message: 'instrumentation discrepancy: missing functions from source code',
       moduleInfo,
       snapshotInfo: scriptPathFunctions,
       functionsInfo: {

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -90,6 +90,23 @@ test('test uglify-js method detection', function (t) {
   t.end();
 });
 
+
+test('test explicit fake-anonymous function', function (t) {
+  const contents = `
+const foo = function bar() {
+  function baz() {}
+};
+`;
+  const methods = ['bar', 'bar.baz'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2, 'bar found');
+  t.equal(found[methods[1]].start.line, 3, 'bar.baz found');
+  t.end();
+});
+
 test('test export = { f() {} } method detection', function (t) {
   const contents = `
 module.exports = {
@@ -192,6 +209,24 @@ function foo() {
   );
   t.same(sorted(Object.keys(found)), sorted(methods));
   t.equal(found[methods[0]].start.line, 2, 'foo found');
+  t.end();
+});
+
+test('test return expression parsing', function (t) {
+  const contents = `
+foo(function () {
+  return function bar() {
+    function baz() {}
+  }
+});
+`;
+  const methods = ['bar', 'bar.baz'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 3, 'bar found');
+  t.equal(found[methods[1]].start.line, 4, 'bar.baz found');
   t.end();
 });
 


### PR DESCRIPTION
#### What does this PR do?

Handle functions with names in expression context, iff they are not being used in a recognised expression context.

Handle functions in `return` statements, which is not an expression context.

We see this in `iter`'s uglified module wrapper. We still don't really see the useful functions in `iter`, but they are ... a mess.