### PR TITLE
feat: support literals in object keys

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -97,12 +97,12 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
       }
       break;
     case 'Property':
-      const key = node.key;
-      if (key.type !== 'Identifier') {
+      const key = unpackName(node.key);
+      if (0 === key.length) {
         // e.g. { ["concatenation" + "here"]: 5 }
         return;
       }
-      inspectNode(node.value, path.concat(key.name), cb, true);
+      inspectNode(node.value, path.concat(key), cb, true);
       break;
     case 'ClassDeclaration': {
       const name = node.id;
@@ -153,6 +153,9 @@ function unpackName(node) {
     }
     case 'Identifier':
       name.push(node.name);
+      break;
+    case 'Literal':
+      name.push(node.value);
       break;
   }
 

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -163,6 +163,23 @@ test('test inner function function detection', function (t) {
   t.end();
 });
 
+test('test literals in objects detection', function (t) {
+  const contents = `
+console.log({
+  1: function() { function foo() { } },
+  'foo-bar': function() { function foo_bar() { } },
+});
+`;
+  const methods = ['1.foo', 'foo-bar.foo_bar'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 3, 'foo found');
+  t.equal(found[methods[1]].start.line, 4, 'foo_bar found');
+  t.end();
+});
+
 test('test lodash-CC-style function detection', function (t) {
   const contents = `
 ;(function() {


### PR DESCRIPTION
#### What does this PR do?

Handle some non-identifiers in object literal keys.

`unpackName` could already handle identifiers as we expect, so just extend it to support `Literal`.