### PR TITLE
feat: duplicate emission of function expressions

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -41,19 +41,26 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
       break;
     }
     case 'FunctionExpression': {
-      let newPath = path;
       const name = unpackName(node.id);
+      const extendedPath = path.concat(name);
 
       if (expectingAnonymousDeclaration) {
         // if we're in a context where anonymous makes sense,
-        // we discard the function name, to avoid duplication
+        // emit both, and recurse ignoring the function name
         cb(path, node.body.loc);
-      } else if (0 !== name.length) {
-        newPath = path.concat(name);
-        cb(newPath, node.body.loc);
-      }
+        cb(extendedPath, node.body.loc);
+        inspectNode(node.body, path, cb);
+      } else {
+        // if we're not expecting an anonymous declaration,
+        // and there is a name, emit it
+        if (0 !== name.length) {
+          cb(extendedPath, node.body.loc);
+        }
 
-      inspectNode(node.body, newPath, cb);
+        // recurse using the extended path (which will be the same
+        // as the non-extended one for empty names).
+        inspectNode(node.body, extendedPath, cb);
+      }
       break;
     }
     case 'ExpressionStatement':

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -69,6 +69,34 @@ console.log([function() {
   t.end();
 });
 
+test('test named expression duplication', function (t) {
+  const contents = `
+console.log({
+  foo: function(outer) {
+    outer.exports = function yellow() {};
+  },
+  bar: function(outer) {
+    outer.exports = function green() {};
+  },
+});
+`;
+  const methods = [
+    'foo.outer.exports',
+    'foo.outer.exports.yellow',
+    'bar.outer.exports',
+    'bar.outer.exports.green',
+  ];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 4, 'exp the first time');
+  t.equal(found[methods[1]].start.line, 4, 'exp.yellow');
+  t.equal(found[methods[2]].start.line, 7, 'exp again');
+  t.equal(found[methods[3]].start.line, 7, 'exp.green');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];


### PR DESCRIPTION
#### What does this PR do?

Emit *both* the anonymous and non-anonymous names for function expressions.

This feels more natural for cases like `underscore.string`'s wrapper, although it's not ideal for that particular case.