### PR TITLE
feat: support functions declared in if statements

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -56,6 +56,11 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
       inspectNode(node.body, newPath, cb);
       break;
     }
+    case 'IfStatement':
+      inspectNode(node.test, path, cb);
+      inspectNode(node.consequent, path, cb);
+      inspectNode(node.alternate, path, cb);
+      break;
     case 'ExpressionStatement':
       inspectNode(node.expression, path, cb);
       break;

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -69,6 +69,28 @@ console.log([function() {
   t.end();
 });
 
+test('test if body inspection', function (t) {
+  const contents = `
+if (console.singular) {
+  function foo() {}
+}
+if (console.both) {
+  function bar() {}
+} else {
+  function baz() {}
+}
+`;
+  const methods = ['bar', 'baz', 'foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 6, 'foo');
+  t.equal(found[methods[1]].start.line, 8, 'bar');
+  t.equal(found[methods[2]].start.line, 3, 'baz');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];


### PR DESCRIPTION
#### What does this PR do?

Spot this function:

```
if (foo) {
  function bar() {}
}
```

We've seen this in `crypto-browserify`.

### Review questions

 * `node.alternate` (the `else` block) can be `null`/`undefined`. This is handled by the `if (!node) {` check at the top of `inspectNode`. Would it be clearer to check it explicitly?
