### PR TITLE
Feat/allow ignoring unknown ca

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ function initConfig(startingConfig) {
   config['snapshotIntervalMs'] = 60 * 60 * 1000;
   config['beaconUrl'] = 'https://homebase.snyk.io/api/v1/beacon';
   config['snapshotUrl'] = `https://homebase.snyk.io/api/v2/snapshot/${startingConfig.projectId}/node`;
+  config['allowUnknownCA'] = false;
 
   config['functionPaths'] = {
     repo: {
@@ -37,6 +38,7 @@ function initConfig(startingConfig) {
   const overrideables = [
     'snapshotUrl', 'snapshotIntervalMs', 'beaconIntervalMs',
     'enable', 'flushOnExit', 'projectId', 'functionPaths',
+    'allowUnknownCA',
   ];
   for (const key of overrideables) {
     if (key in startingConfig) {

--- a/lib/snapshot/reader.js
+++ b/lib/snapshot/reader.js
@@ -49,6 +49,7 @@ async function loadFromUpstream() {
     debug(`attempting to retrieve latest snapshot from ${url}`);
     const requestOptions = {
       json: true,
+      rejectUnauthorized: !config['allowUnknownCA'],
       headers: {'If-Modified-Since': lastModified.toUTCString()},
     };
     const response = await needle('get', url, requestOptions);

--- a/lib/transmitter.js
+++ b/lib/transmitter.js
@@ -24,7 +24,12 @@ function transmitEvents(url, projectId, agentId) {
     loadedSources: currentState.packages,
   };
 
-  postPromise = needle('post', url, body, {json: true})
+  const options = {
+    json: true,
+    rejectUnauthorized: !config['allowUnknownCA'],
+  };
+
+  postPromise = needle('post', url, body, options)
     .then((response) => {
       if (response && response.statusCode !== 200) {
         debug('Unexpected response for events transmission: ' +


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Any changes involving paths support all path separators
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

introduce a new, undocumented flag for allowing the agent to ignore unknown CAs when sending beacons.
this flag is used both in transmissions (sending beacons) and reading snapshots.
also enhanced our transmitter & snapshot reading tests a bit

#### Any background context you want to provide?

main motivation for this feature is on-prem setups where users might not wish to use certificates with known CAs (or teach the agent which CAs are trusted)

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-208