### PR TITLE
feat: alias export default -> module.exports

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -88,6 +88,9 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
     case 'ExportNamedDeclaration':
       inspectNode(node.declaration, path, cb);
       break;
+    case 'ExportDefaultDeclaration':
+      inspectNode(node.declaration, path.concat('module.exports'), cb, true);
+      break;
     case 'AssignmentExpression': {
       inspectNode(node.left, path, cb);
       inspectNode(node.right, path.concat(unpackName(node.left)), cb, true);

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -177,6 +177,20 @@ module.exports = {
   t.end();
 });
 
+test('test export default method detection', function (t) {
+  const contents = `
+export default function() {}
+`;
+  const methods = ['module.exports'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 2,
+    'export default aliased to module.exports');
+  t.end();
+});
+
 test('test class member detection', function (t) {
   const contents = `
 class Moog {


### PR DESCRIPTION
#### What does this PR do?

Treat:
```
export default function() {}
````

...as if the user had written:
```
module.exports = function() {}
```