### PR TITLE
Upgrade travis to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 notifications:
   email: false


### PR DESCRIPTION
#### What does this PR do?

Use `xenial` (2016) for the travis base image, instead of `trusty` (2014). `bionic` (2018) isn't available yet.

Follows #90.