### PR TITLE
feat: allow lazy || wrapper classes

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -96,6 +96,10 @@ function inspectNode(node, path, cb, expectingAnonymousDeclaration) {
       inspectNode(node.right, path.concat(unpackName(node.left)), cb, true);
       break;
     }
+    case 'LogicalExpression':
+      inspectNode(node.left, path, cb);
+      inspectNode(node.right, path, cb);
+      break;
     case 'UnaryExpression':
       inspectNode(node.argument, path, cb);
       break;

--- a/test/method-detection.test.js
+++ b/test/method-detection.test.js
@@ -107,6 +107,21 @@ if (console.both) {
   t.end();
 });
 
+test('test lazy class declaration', function (t) {
+  const contents = `
+var Class = Class || (function (Object) {
+  function foo() {}
+});
+`;
+  const methods = ['Class.foo'];
+  const found = ast.findAllVulnerableFunctionsInScript(
+    contents, methods,
+  );
+  t.same(sorted(Object.keys(found)), sorted(methods));
+  t.equal(found[methods[0]].start.line, 3, 'foo');
+  t.end();
+});
+
 test('test st method detection', function (t) {
   const content = fs.readFileSync(__dirname + '/fixtures/st/node_modules/st.js');
   const methods = ['Mount.prototype.getPath'];


### PR DESCRIPTION
#### What does this PR do?

Detect:
```
var Class = Class || (function (Object) {
  function foo() {}
});
```

.. as `Class.foo`. We saw this in `es-class`.