### PR TITLE
feat: upgrade needle (redirect bug)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,9 +1956,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "acorn": "5.7.4",
     "debug": "^4.1.1",
-    "needle": "^2.4.0",
+    "needle": "^2.5.0",
     "semver": "^6.3.0",
     "uuid": "^3.3.3"
   }


### PR DESCRIPTION
needle has a bug with sockets on newer node 12,
we're currently avoiding this newer node 12 to
evade the problem. This bug is fixed in needle
2.5.0, so let's upgrade to that.

https://github.com/tomas/needle/issues/312
